### PR TITLE
fix : Redis에 RefreshToken 저장 시 512MB가 넘는다는 에러 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'it.ozimov:embedded-redis:0.7.1'
+    testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/pokemon/splender/jwt/service/RefreshTokenService.java
+++ b/src/main/java/pokemon/splender/jwt/service/RefreshTokenService.java
@@ -1,5 +1,6 @@
 package pokemon.splender.jwt.service;
 
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -31,7 +32,7 @@ public class RefreshTokenService {
     // Long expirationTime에 TTL 설정하면 됨
     public void saveRefreshToken(Long userId, String refreshToken, Long expirationTime) {
         String key = getRefreshTokenKey(userId);
-        redisTemplate.opsForValue().set(key, refreshToken, expirationTime);
+        redisTemplate.opsForValue().set(key, refreshToken, Duration.ofMillis(expirationTime));
     }
 
     // Redis에서 RefreshToken 값 조회

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=none

--- a/src/test/java/pokemon/splender/config/RedisConfigTest.java
+++ b/src/test/java/pokemon/splender/config/RedisConfigTest.java
@@ -8,8 +8,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 // Embedded Redis 적용
 @Import(EmbeddedRedisConfig.class)
 class RedisConfigTest {


### PR DESCRIPTION
## 📝 작업 내용

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
Redis에 RefreshToken 저장 시 512MB가 넘는다는 에러가 발생했습니다. 토큰을 저장할 때 TTL 부분의 타입 지정이 잘못 되어 있어 에러가 발생한다는 것을 확인하여 수정하였습니다.
추가로 테스트 환경에서 db가 실행되도록 h2 db를 테스트 환경에서만 돌아가게 추가했습니다.

## 🛠️ PR 유형

- [ ]  새로운 기능 추가
- [X]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [X]  테스트 추가, 테스트 리팩토링
- [X]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## 💬 리뷰 요구사항

<!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분 적기 -->
<!-- 논의해야 할 부분 적기 -->

## #️⃣연관된 이슈

<!-- 연관된 이슈 번호 적기 -->
close #16 
