### PR TITLE
feat : 로컬 환경의 이미지 제공하는 API 구현

### DIFF
--- a/src/main/java/pokemon/splender/config/ImageCacheInitializer.java
+++ b/src/main/java/pokemon/splender/config/ImageCacheInitializer.java
@@ -19,11 +19,11 @@ public class ImageCacheInitializer {
     // 프로그램 시작 시 캐싱
     @PostConstruct
     public void init() {
-        List<String> group = List.of(
+        List<String> groups = List.of(
             "level1", "level2", "level3", "back", "legend", "rare", "token"
         );
 
-        for (String groupName : group) {
+        for (String groupName : groups) {
             String pathPrefix = imageBasePath + groupName + "/";
             imageService.cacheImageGroup(groupName, pathPrefix);
         }

--- a/src/main/java/pokemon/splender/config/ImageCacheInitializer.java
+++ b/src/main/java/pokemon/splender/config/ImageCacheInitializer.java
@@ -1,0 +1,33 @@
+package pokemon.splender.config;
+
+import jakarta.annotation.PostConstruct;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import pokemon.splender.image.service.ImageService;
+
+@Component
+@RequiredArgsConstructor
+public class ImageCacheInitializer {
+
+    private final ImageService imageService;
+
+    @Value("${image.base-path}")
+    private String imageBasePath;
+
+    // 프로그램 시작 시 캐싱
+    @PostConstruct
+    public void init() {
+        List<String> group = List.of(
+            "level1", "level2", "level3", "back", "legend", "rare", "token"
+        );
+
+        for (String groupName : group) {
+            String pathPrefix = imageBasePath + groupName + "/";
+            imageService.cacheImageGroup(groupName, pathPrefix);
+        }
+
+    }
+
+}

--- a/src/main/java/pokemon/splender/exception/CustomMVCException.java
+++ b/src/main/java/pokemon/splender/exception/CustomMVCException.java
@@ -1,7 +1,9 @@
 package pokemon.splender.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static pokemon.splender.exception.ErrorMessage.INVALID_IMAGE;
 import static pokemon.splender.exception.ErrorMessage.INVALID_NAME_CHANGE_PERIOD;
+import static pokemon.splender.exception.ErrorMessage.NOT_EXIST_IMAGE;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -16,5 +18,13 @@ public class CustomMVCException extends RuntimeException {
 
     public static CustomMVCException invalidNameChangePeriod() {
         return new CustomMVCException(INVALID_NAME_CHANGE_PERIOD, BAD_REQUEST);
+    }
+
+    public static CustomMVCException invalidImage() {
+        return new CustomMVCException(INVALID_IMAGE, BAD_REQUEST);
+    }
+
+    public static CustomMVCException notExistImage() {
+        return new CustomMVCException(NOT_EXIST_IMAGE, BAD_REQUEST);
     }
 }

--- a/src/main/java/pokemon/splender/exception/CustomMVCException.java
+++ b/src/main/java/pokemon/splender/exception/CustomMVCException.java
@@ -6,22 +6,37 @@ import static pokemon.splender.exception.ErrorMessage.INVALID_NAME_CHANGE_PERIOD
 import static pokemon.splender.exception.ErrorMessage.NOT_EXIST_IMAGE;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
-@RequiredArgsConstructor
 public class CustomMVCException extends RuntimeException {
 
     private final ErrorMessage errorMessage;
     private final HttpStatus status;
+    private final String detail; // 명확한 오류 메시지
+
+    // 이미지 관련 제외 나머지는 detail이 필요 없으므로
+    // RequiredArgsConstructor 제거 후 직접 생성자 추가
+    public CustomMVCException(ErrorMessage errorMessage, HttpStatus status) {
+        this.errorMessage = errorMessage;
+        this.status = status;
+        this.detail = null;
+    }
+
+    public CustomMVCException(ErrorMessage errorMessage, HttpStatus status, String detail) {
+        this.errorMessage = errorMessage;
+        this.status = status;
+        this.detail = detail;
+    }
+
 
     public static CustomMVCException invalidNameChangePeriod() {
         return new CustomMVCException(INVALID_NAME_CHANGE_PERIOD, BAD_REQUEST);
     }
 
-    public static CustomMVCException invalidImage() {
-        return new CustomMVCException(INVALID_IMAGE, BAD_REQUEST);
+    // 명확한 오류 메시지를 포함하기 위해 String detail 추가
+    public static CustomMVCException invalidImage(String detail) {
+        return new CustomMVCException(INVALID_IMAGE, BAD_REQUEST, detail);
     }
 
     public static CustomMVCException notExistImage() {

--- a/src/main/java/pokemon/splender/exception/ErrorMessage.java
+++ b/src/main/java/pokemon/splender/exception/ErrorMessage.java
@@ -21,7 +21,13 @@ public enum ErrorMessage {
 
     //token 관련 문제
     INVALID_TOKEN(-10200, "유효하지 않은 토큰입니다."),
-    EXPIRED_TOKEN(-10201, "만료된 토큰입니다.");
+    EXPIRED_TOKEN(-10201, "만료된 토큰입니다."),
+
+
+    // image 관련 문제
+    INVALID_IMAGE(-10300, "유효하지 않은 이미지입니다."),
+    NOT_EXIST_IMAGE(-10301, "이미지가 존재하지 않습니다.");
+
 
 
     private final int code;

--- a/src/main/java/pokemon/splender/exception/ErrorResponse.java
+++ b/src/main/java/pokemon/splender/exception/ErrorResponse.java
@@ -1,0 +1,15 @@
+package pokemon.splender.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// 값이 null일 때 JSON에서 제외 가능
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private int code;
+    private String message;
+    private String detail; // null 가능
+}

--- a/src/main/java/pokemon/splender/exception/handler/GlobalMVCExceptionHandler.java
+++ b/src/main/java/pokemon/splender/exception/handler/GlobalMVCExceptionHandler.java
@@ -5,15 +5,21 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import pokemon.splender.exception.CustomMVCException;
 import pokemon.splender.exception.ErrorMessage;
+import pokemon.splender.exception.ErrorResponse;
 
 @RestControllerAdvice
 public class GlobalMVCExceptionHandler {
 
     @ExceptionHandler(CustomMVCException.class)
-    public ResponseEntity<ErrorMessage> handleCustomException(CustomMVCException customException) {
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomMVCException customException) {
+        ErrorMessage errorMessage = customException.getErrorMessage();
+        ErrorResponse errorResponse = new ErrorResponse(
+            errorMessage.getCode(),
+            errorMessage.getMessage(),
+            customException.getDetail()
+        );
 
-        return new ResponseEntity<>(
-            customException.getErrorMessage(),
+        return new ResponseEntity<>(errorResponse,
             customException.getStatus());
     }
 }

--- a/src/main/java/pokemon/splender/image/controller/ImageController.java
+++ b/src/main/java/pokemon/splender/image/controller/ImageController.java
@@ -4,6 +4,9 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +27,12 @@ public class ImageController {
     ) {
         Map<Long, String> imageMap = imageService.getImagesByIds(ids);
         return CustomResponse.ok(imageMap);
+    }
+
+    @GetMapping("/profile/{userId}")
+    public ResponseEntity<String> getProfileImage(@PathVariable Long userId) {
+        String image = imageService.getImagebyId(userId);
+        return CustomResponse.ok(image);
     }
 
 }

--- a/src/main/java/pokemon/splender/image/controller/ImageController.java
+++ b/src/main/java/pokemon/splender/image/controller/ImageController.java
@@ -31,7 +31,7 @@ public class ImageController {
 
     @GetMapping("/profile/{userId}")
     public ResponseEntity<String> getProfileImage(@PathVariable Long userId) {
-        String image = imageService.getImagebyId(userId);
+        String image = imageService.getImageById(userId);
         return CustomResponse.ok(image);
     }
 

--- a/src/main/java/pokemon/splender/image/controller/ImageController.java
+++ b/src/main/java/pokemon/splender/image/controller/ImageController.java
@@ -1,0 +1,29 @@
+package pokemon.splender.image.controller;
+
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import pokemon.splender.image.service.ImageService;
+import pokemon.splender.response.CustomResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/images")
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping
+    public ResponseEntity<Map<Long, String>> getImagesByIds(
+        @RequestBody List<Long> ids
+    ) {
+        Map<Long, String> imageMap = imageService.getImagesByIds(ids);
+        return CustomResponse.ok(imageMap);
+    }
+
+}

--- a/src/main/java/pokemon/splender/image/controller/ImageController.java
+++ b/src/main/java/pokemon/splender/image/controller/ImageController.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/pokemon/splender/image/entity/Image.java
+++ b/src/main/java/pokemon/splender/image/entity/Image.java
@@ -1,0 +1,26 @@
+package pokemon.splender.image.entity;
+
+
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "images")
+@NoArgsConstructor(access = PROTECTED)
+public class Image {
+
+    @Id
+    @Getter
+    private Long id;
+
+    @Getter
+    @Column(nullable = false)
+    private String path;
+
+}

--- a/src/main/java/pokemon/splender/image/repository/ImageRepository.java
+++ b/src/main/java/pokemon/splender/image/repository/ImageRepository.java
@@ -1,11 +1,10 @@
 package pokemon.splender.image.repository;
 
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import pokemon.splender.image.entity.Image;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
 
-    Optional<List<Image>> findByIdIn(List<Long> ids);
+    List<Image> findByIdIn(List<Long> ids);
 }

--- a/src/main/java/pokemon/splender/image/repository/ImageRepository.java
+++ b/src/main/java/pokemon/splender/image/repository/ImageRepository.java
@@ -1,0 +1,11 @@
+package pokemon.splender.image.repository;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import pokemon.splender.image.entity.Image;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+
+    Optional<List<Image>> findByIdIn(List<Long> ids);
+}

--- a/src/main/java/pokemon/splender/image/repository/ImageRepository.java
+++ b/src/main/java/pokemon/splender/image/repository/ImageRepository.java
@@ -7,4 +7,9 @@ import pokemon.splender.image.entity.Image;
 public interface ImageRepository extends JpaRepository<Image, Long> {
 
     List<Image> findByIdIn(List<Long> ids);
+
+    // Path(폴더)별로 이미지 찾기
+    // 다음과 같은 쿼리 의미를 가짐
+    // SELECT i FROM Image i WHERE i.path LIKE CONCAT(:basePath, '%')
+    List<Image> findAllByPathStartingWith(String basePath);
 }

--- a/src/main/java/pokemon/splender/image/service/ImageService.java
+++ b/src/main/java/pokemon/splender/image/service/ImageService.java
@@ -3,6 +3,8 @@ package pokemon.splender.image.service;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -31,11 +33,11 @@ public class ImageService {
 
         for (Image image : images) {
             try {
-                // 이미지 경로로부터 File 객체 생성
-                File file = new File(image.getPath());
+                // 이미지 경로로부터 Path 객체 생성
+                Path path = Paths.get(image.getPath());
 
                 // 이미지 파일을 바이트 배열로 읽음
-                byte[] bytes = Files.readAllBytes(file.toPath());
+                byte[] bytes = Files.readAllBytes(path);
 
                 // 이미지를 Base64 문자열로 인코딩
                 String base64Image = Base64.getEncoder().encodeToString(bytes);

--- a/src/main/java/pokemon/splender/image/service/ImageService.java
+++ b/src/main/java/pokemon/splender/image/service/ImageService.java
@@ -7,7 +7,6 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import pokemon.splender.exception.CustomMVCException;
@@ -22,13 +21,12 @@ public class ImageService {
 
     public Map<Long, String> getImagesByIds(List<Long> ids) {
         // DB에서 이미지 경로 가져오기
-        Optional<List<Image>> optionalImages = imageRepository.findByIdIn(ids);
+        List<Image> images = imageRepository.findByIdIn(ids);
 
-        if (optionalImages.isEmpty()) {
+        if (images.isEmpty()) {
             throw CustomMVCException.notExistImage();
         }
 
-        List<Image> images = optionalImages.get();
         Map<Long, String> result = new HashMap<>();
 
         for (Image image : images) {

--- a/src/main/java/pokemon/splender/image/service/ImageService.java
+++ b/src/main/java/pokemon/splender/image/service/ImageService.java
@@ -44,7 +44,7 @@ public class ImageService {
 
                 result.put(image.getId(), base64Image);
             } catch (IOException e) {
-                throw CustomMVCException.invalidImage();
+                throw CustomMVCException.invalidImage(e.getMessage());
             }
         }
         return result;

--- a/src/main/java/pokemon/splender/image/service/ImageService.java
+++ b/src/main/java/pokemon/splender/image/service/ImageService.java
@@ -34,6 +34,11 @@ public class ImageService {
         Map<Long, String> result = new HashMap<>();
 
         for (Image image : images) {
+
+            if (image.getPath() == null || image.getPath().isBlank()) {
+                throw CustomMVCException.invalidImage("이미지 경로가 비어있습니다. imageId : " + image.getId());
+            }
+
             result.put(image.getId(),image.getPath());
         }
         return result;
@@ -42,6 +47,11 @@ public class ImageService {
     public String getImageById(Long id) {
         Image image = imageRepository.findById(id)
             .orElseThrow(() -> CustomMVCException.notExistImage());
+
+        if (image.getPath() == null || image.getPath().isBlank()) {
+            throw CustomMVCException.invalidImage("이미지 경로가 비어있습니다. imageId : " + image.getId());
+        }
+
         return image.getPath();
     }
 
@@ -51,7 +61,16 @@ public class ImageService {
     public void cacheImageGroup(String group, String pathPrefix) {
         List<Image> images = imageRepository.findAllByPathStartingWith(pathPrefix);
 
+        if (images.isEmpty()) {
+            throw CustomMVCException.notExistImage();
+        }
+
         for (Image image : images) {
+
+            if (image.getPath() == null || image.getPath().isBlank()) {
+                throw CustomMVCException.invalidImage("이미지 경로가 비어있습니다. imageId : " + image.getId());
+            }
+
             String redisKey = "image:" + group + ":" + image.getId();
             redisTemplate.opsForValue().set(redisKey, image.getPath());
         }

--- a/src/main/java/pokemon/splender/image/service/ImageService.java
+++ b/src/main/java/pokemon/splender/image/service/ImageService.java
@@ -50,4 +50,18 @@ public class ImageService {
         return result;
     }
 
+    public String getImagebyId(Long id) {
+        Image image = imageRepository.findById(id)
+            .orElseThrow(() -> CustomMVCException.notExistImage());
+
+        try {
+            Path path = Paths.get(image.getPath());
+            byte[] bytes = Files.readAllBytes(path);
+            String base64Image = Base64.getEncoder().encodeToString(bytes);
+            return base64Image;
+        } catch (IOException e) {
+            throw CustomMVCException.invalidImage(e.getMessage());
+        }
+    }
+
 }

--- a/src/main/java/pokemon/splender/image/service/ImageService.java
+++ b/src/main/java/pokemon/splender/image/service/ImageService.java
@@ -1,11 +1,5 @@
 package pokemon.splender.image.service;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/pokemon/splender/image/service/ImageService.java
+++ b/src/main/java/pokemon/splender/image/service/ImageService.java
@@ -1,0 +1,53 @@
+package pokemon.splender.image.service;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import pokemon.splender.exception.CustomMVCException;
+import pokemon.splender.image.entity.Image;
+import pokemon.splender.image.repository.ImageRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final ImageRepository imageRepository;
+
+    public Map<Long, String> getImagesByIds(List<Long> ids) {
+        // DB에서 이미지 경로 가져오기
+        Optional<List<Image>> optionalImages = imageRepository.findByIdIn(ids);
+
+        if (optionalImages.isEmpty()) {
+            throw CustomMVCException.notExistImage();
+        }
+
+        List<Image> images = optionalImages.get();
+        Map<Long, String> result = new HashMap<>();
+
+        for (Image image : images) {
+            try {
+                // 이미지 경로로부터 File 객체 생성
+                File file = new File(image.getPath());
+
+                // 이미지 파일을 바이트 배열로 읽음
+                byte[] bytes = Files.readAllBytes(file.toPath());
+
+                // 이미지를 Base64 문자열로 인코딩
+                String base64Image = Base64.getEncoder().encodeToString(bytes);
+
+                result.put(image.getId(), base64Image);
+            } catch (IOException e) {
+                throw CustomMVCException.invalidImage();
+            }
+        }
+        return result;
+    }
+
+}

--- a/src/main/java/pokemon/splender/image/service/ImageService.java
+++ b/src/main/java/pokemon/splender/image/service/ImageService.java
@@ -52,7 +52,7 @@ public class ImageService {
         return result;
     }
 
-    public String getImagebyId(Long id) {
+    public String getImageById(Long id) {
         Image image = imageRepository.findById(id)
             .orElseThrow(() -> CustomMVCException.notExistImage());
 

--- a/src/main/java/pokemon/splender/image/service/ImageService.java
+++ b/src/main/java/pokemon/splender/image/service/ImageService.java
@@ -34,20 +34,7 @@ public class ImageService {
         Map<Long, String> result = new HashMap<>();
 
         for (Image image : images) {
-            try {
-                // 이미지 경로로부터 Path 객체 생성
-                Path path = Paths.get(image.getPath());
-
-                // 이미지 파일을 바이트 배열로 읽음
-                byte[] bytes = Files.readAllBytes(path);
-
-                // 이미지를 Base64 문자열로 인코딩
-                String base64Image = Base64.getEncoder().encodeToString(bytes);
-
-                result.put(image.getId(), base64Image);
-            } catch (IOException e) {
-                throw CustomMVCException.invalidImage(e.getMessage());
-            }
+            result.put(image.getId(),image.getPath());
         }
         return result;
     }
@@ -55,15 +42,7 @@ public class ImageService {
     public String getImageById(Long id) {
         Image image = imageRepository.findById(id)
             .orElseThrow(() -> CustomMVCException.notExistImage());
-
-        try {
-            Path path = Paths.get(image.getPath());
-            byte[] bytes = Files.readAllBytes(path);
-            String base64Image = Base64.getEncoder().encodeToString(bytes);
-            return base64Image;
-        } catch (IOException e) {
-            throw CustomMVCException.invalidImage(e.getMessage());
-        }
+        return image.getPath();
     }
 
     // Path별로 이미지를 찾은 후 Redis에 값 저장
@@ -73,16 +52,8 @@ public class ImageService {
         List<Image> images = imageRepository.findAllByPathStartingWith(pathPrefix);
 
         for (Image image : images) {
-            try {
-                Path path = Paths.get(image.getPath());
-                byte[] bytes = Files.readAllBytes(path);
-                String base64Image = Base64.getEncoder().encodeToString(bytes);
-
-                String redisKey = "image:" + group + ":" + image.getId();
-                redisTemplate.opsForValue().set(redisKey, base64Image);
-            } catch (IOException e) {
-                throw CustomMVCException.invalidImage(e.getMessage());
-            }
+            String redisKey = "image:" + group + ":" + image.getId();
+            redisTemplate.opsForValue().set(redisKey, image.getPath());
         }
     }
 

--- a/src/main/java/pokemon/splender/response/CustomResponse.java
+++ b/src/main/java/pokemon/splender/response/CustomResponse.java
@@ -12,4 +12,8 @@ public class CustomResponse {
     public static ResponseEntity<Void> noContent() {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
+
+    public static <T> ResponseEntity<T> ok(T data) {
+        return ResponseEntity.status(HttpStatus.OK).body(data);
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -37,3 +37,6 @@ jwt.refresh-token-expiration=604800000
 spring.data.redis.host=localhost
 spring.data.redis.port=6379
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+
+# image
+image.base-path=C:/pokemon_splender/


### PR DESCRIPTION
## 📝 작업 내용

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
`POST /api/images` 요청 시,  Body에 ID 리스트를 넘기면 해당 이미지들을 Base64 인코딩된 형태로 반환합니다.
반환된 값이 사진으로 잘 나오는지는 다음의 사이트에서 확인이 가능합니다.
https://ko.rakko.tools/tools/71/

## 🛠️ PR 유형

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [x]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## 💬 리뷰 요구사항

<!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분 적기 -->
<!-- 논의해야 할 부분 적기 -->
- 이미지 파일을 읽어 base64로 변환하는 방식이 적절한지 논의해야 합니다. 실제로 변환된 값을 봤을 때 길이가 엄청 길게 출력됩니다.
- 여러 이미지를 한 요청에 담아 응답하는 구조가 괜찮은지 논의해야 합니다. 어떻게 값을 반환해줘야 할 지 몰라 일단 Map 형식으로 반환하도록 했습니다.
- 예외 처리 방식이 괜찮은지 확인해야 합니다.
- 현재 작성된 코드는 여러 이미지를 제공하는 API입니다. 단일 이미지 제공 API가 필요한지 확인해야 합니다.

## #️⃣연관된 이슈

<!-- 연관된 이슈 번호 적기 -->
#18 